### PR TITLE
Move SPI functions to WireHelper library, reducing binary size when working with multiple sensors

### DIFF
--- a/Adafruit_L3GD20_U.h
+++ b/Adafruit_L3GD20_U.h
@@ -24,7 +24,6 @@
 #endif
 
 #include <Adafruit_Sensor.h>
-#include <Wire.h>
 
 /*=========================================================================
     I2C ADDRESS/BITS AND SETTINGS
@@ -120,8 +119,6 @@ class Adafruit_L3GD20_Unified : public Adafruit_Sensor
     gyro_type type;
 
   private:
-    void        write8  ( byte reg, byte value );
-    byte        read8   ( byte reg );
     gyroRange_t _range;
     int32_t     _sensorID;
 };

--- a/examples/sensorapi/sensorapi.pde
+++ b/examples/sensorapi/sensorapi.pde
@@ -1,4 +1,5 @@
 #include <Wire.h>
+#include <WireHelper.h>
 #include <Adafruit_Sensor.h>
 #include <Adafruit_L3GD20_U.h>
 


### PR DESCRIPTION
This branch removes the write8, read8, and similar methods to the [WireHelper](https://github.com/therealmitchconnors/WireHelper) library, which should significantly reduce binary size on projects using multiple sensors, as long as they all use the WireHelper library.  

Note: This pull request is not yet ready to merge, as the WireHelper library is still in pre-release.  @microbuilder asked that I create an issue that would help him to review this when he gets time.
