### PR TITLE
checking the return value of endTransmission. 

### DIFF
--- a/Adafruit_L3GD20_U.cpp
+++ b/Adafruit_L3GD20_U.cpp
@@ -238,11 +238,11 @@ bool Adafruit_L3GD20_Unified::getEvent(sensors_event_t* event)
     #else
       Wire.send(GYRO_REGISTER_OUT_X_L | 0x80);
     #endif
-    Wire.endTransmission();
+    if (Wire.endTransmission() != 0) {
+        // Error. Retry.
+        continue;
+    }
     Wire.requestFrom((byte)L3GD20_ADDRESS, (byte)6);
-
-    /* Wait around until enough data is available */
-    while (Wire.available() < 6);
 
     #if ARDUINO >= 100
       uint8_t xlo = Wire.read();


### PR DESCRIPTION
Transmissions can fail and are failing sometimes for my gyro. It's necessary to check the return value of endTransmission.

No need to loop after requestFrom. Buffers are read already.