### PR TITLE
Enable Data Ready interrupt

### DIFF
--- a/Adafruit_L3GD20_U.cpp
+++ b/Adafruit_L3GD20_U.cpp
@@ -256,6 +256,19 @@ void Adafruit_L3GD20_Unified::enableDRDYInterrupt(bool enabled)
 }
 
 /**************************************************************************/
+/*!
+    @brief  Sets the Output Data Rate
+*/
+/**************************************************************************/
+void Adafruit_L3GD20_Unified::setOutputDataRate(gyroDataRate odr)
+{
+  byte existing = read8(GYRO_REGISTER_CTRL_REG1);
+
+  write8(GYRO_REGISTER_CTRL_REG1, existing &= ~(3<<6));
+  write8(GYRO_REGISTER_CTRL_REG1, existing |= odr<<6);
+}
+
+/**************************************************************************/
 /**
     @brief  Gets the most recent sensor event, containing a new sample
             from the sensor.

--- a/Adafruit_L3GD20_U.cpp
+++ b/Adafruit_L3GD20_U.cpp
@@ -240,6 +240,22 @@ void Adafruit_L3GD20_Unified::enableAutoRange(bool enabled)
 }
 
 /**************************************************************************/
+/*!
+    @brief  Enables (or disables) the Data Ready interrupt
+*/
+/**************************************************************************/
+void Adafruit_L3GD20_Unified::enableDRDYInterrupt(bool enabled)
+{
+  byte existing = read8(GYRO_REGISTER_CTRL_REG3);
+
+  if (enabled) {
+    write8(GYRO_REGISTER_CTRL_REG3, existing |= 1<<3);
+  } else {
+    write8(GYRO_REGISTER_CTRL_REG3, existing &= ~(1<<3));
+  }
+}
+
+/**************************************************************************/
 /**
     @brief  Gets the most recent sensor event, containing a new sample
             from the sensor.

--- a/Adafruit_L3GD20_U.h
+++ b/Adafruit_L3GD20_U.h
@@ -109,6 +109,7 @@ class Adafruit_L3GD20_Unified : public Adafruit_Sensor
 
     bool begin           ( gyroRange_t rng = GYRO_RANGE_250DPS, TwoWire *theWire=&Wire);
     void enableAutoRange ( bool enabled );
+    void enableDRDYInterrupt ( bool enabled );
     bool getEvent        ( sensors_event_t* );
     void getSensor       ( sensor_t* );
 

--- a/Adafruit_L3GD20_U.h
+++ b/Adafruit_L3GD20_U.h
@@ -85,6 +85,18 @@
 /*=========================================================================*/
 
 /*=========================================================================
+    OUTPUT DATA RATE SETTINGS
+    -----------------------------------------------------------------------*/
+    typedef enum
+    {
+      GYRO_ODR_95                       = 0x00, // 95 Hz
+      GYRO_ODR_190                      = 0x01, // 190 Hz
+      GYRO_ODR_380                      = 0x02, // 380 Hz
+      GYRO_ODR_760                      = 0x03 // 760 Hz
+    } gyroDataRate;
+/*=========================================================================*/
+
+/*=========================================================================
     RAW GYROSCOPE DATA TYPE
     -----------------------------------------------------------------------*/
     /** Encapsulates a single raw data sample from the sensor. */
@@ -110,6 +122,7 @@ class Adafruit_L3GD20_Unified : public Adafruit_Sensor
     bool begin           ( gyroRange_t rng = GYRO_RANGE_250DPS, TwoWire *theWire=&Wire);
     void enableAutoRange ( bool enabled );
     void enableDRDYInterrupt ( bool enabled );
+    void setOutputDataRate ( gyroDataRate odr );
     bool getEvent        ( sensors_event_t* );
     void getSensor       ( sensor_t* );
 

--- a/examples/interrupt/interrupt.ino
+++ b/examples/interrupt/interrupt.ino
@@ -1,0 +1,88 @@
+/*
+ * L3GD20H Interrupt example.
+ *
+ * Breakout: https://www.adafruit.com/product/1032
+ * 10DOF: https://www.adafruit.com/product/1604
+ *
+ * Connect DRDY (or GRDY on the 10DOF) to interrupt 0
+ */
+
+#include <Wire.h>
+#include <Adafruit_Sensor.h>
+#include <Adafruit_L3GD20_U.h>
+
+
+#define DEBUG
+
+// Set the output rate.  This is independent of the sensor sampling.
+#define SERIAL_OUTPUT_HZ 10
+
+Adafruit_L3GD20_Unified       gyro  = Adafruit_L3GD20_Unified(20);
+
+unsigned int loop_count;
+unsigned int gyro_count;
+
+unsigned long serial_output_timer;
+
+float gx, gy, gz;
+
+volatile boolean gyroDataReady = false;
+
+
+void setup() {
+  Serial.begin(115200);
+
+  attachInterrupt(0, gyroDataReadyISR, RISING);
+
+  if (!gyro.begin(GYRO_RANGE_250DPS)) {
+    Serial.print(F("Ooops, no L3GD20 detected ... Check your wiring or I2C ADDR!"));
+    while(1);
+  }
+  gyro.enableDRDYInterrupt(true);
+  gyro.setOutputDataRate(GYRO_ODR_190);
+}
+
+
+void gyroDataReadyISR () {
+  gyroDataReady = true;
+}
+
+
+void loop() {
+#ifdef DEBUG
+  if (millis() > 1000) {
+    Serial.println();
+    Serial.print(F("Loop count: ")); Serial.println(loop_count);
+    Serial.print(F("L3GD20 reads: ")); Serial.println(gyro_count);
+
+    while(1) {}
+  }
+#endif
+
+  loop_count++;
+
+  if (gyroDataReady) {
+    gyro_count++;
+    gyroDataReady = false;
+
+    sensors_event_t event;
+
+    gyro.getEvent(&event);
+    gx = event.gyro.x;
+    gy = event.gyro.y;
+    gz = event.gyro.z;
+  }
+
+  if (SERIAL_OUTPUT_HZ > 0 && millis() > serial_output_timer + (1000 / SERIAL_OUTPUT_HZ)) {
+    serial_output_timer = millis();
+
+    Serial.print(gx); Serial.print("\t");
+    Serial.print(gy); Serial.print("\t");
+    Serial.println(gz);
+  }
+
+  // Guard against millis() rollover
+  if (serial_output_timer > millis()) {
+    serial_output_timer = 0;
+  }
+}


### PR DESCRIPTION
Enables the use of the Data Ready interrupt as well as the ability to set the output data rate as new methods on the Gyro.  Example for using it also added.

Note that this is an update of #6 (which was abandoned by the original author).